### PR TITLE
Restore WORKLOAD_CPUS to tasket

### DIFF
--- a/cyclictest-client
+++ b/cyclictest-client
@@ -88,7 +88,7 @@ echo -e "${CMD_OUTPUT}"
 HK_CPUS=$(echo -e "${CMD_OUTPUT}" | grep "final cpus:" | awk '{ print $3 }')
 echo "HK_CPUS: ${HK_CPUS}"
 
-cmd="taskset -c $HK_CPUS /usr/bin/cyclictest --policy $policy -i $interval -H 1000 --histfile histogram.txt -D $duration -q -a ${WORKLOAD_CPUS} -t"
+cmd="taskset -c ${WORKLOAD_CPUS},${HK_CPUS} /usr/bin/cyclictest --policy $policy -i $interval -H 1000 --histfile histogram.txt -D $duration -q -a ${WORKLOAD_CPUS} -t"
 echo "About to run: $cmd"
 date +%s.%N >begin.txt
 $cmd >cyclictest-bin-stderrout.txt 2>&1


### PR DESCRIPTION
- cyclictest requires that the CPUs it runs on be defined in it's CPUs
  allowed mask