### PR TITLE
Add distance param

### DIFF
--- a/cyclictest-client
+++ b/cyclictest-client
@@ -25,10 +25,11 @@ policy=fifo
 interval=100
 smt="on"
 break_on=0
+histogram="--histofall 100 --histfile histogram.txt"
 
 
-longopts="duration:,priority:,policy:,interval:,smt:,break-on:"
-opts=$(getopt -q -o "D:p:i:s:b:" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+longopts="duration:,priority:,policy:,interval:,distance:,smt:,break-on:"
+opts=$(getopt -q -o "D:p:i:d:s:b:" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 eval set -- "$opts";
 while true; do
     case "$1" in
@@ -50,6 +51,11 @@ while true; do
         -i|--interval)
             shift
             interval=$1
+            shift
+            ;;
+        -d|--distance)
+            shift
+            distance=$1
             shift
             ;;
         -s|--smt)
@@ -104,12 +110,25 @@ if [ -n "${priority}" ]; then
     prio="--priority ${priority}"
 fi
 
+dist=""
+if [ -n "${distance}" ]; then
+    if [ "${distance}" = "auto" ]; then
+        auto_dist=$((interval / WORKLOAD_CPUS_COUNT))
+        distance=${auto_dist%.*}
+        echo "distance (auto): ${distance}"
+    fi
+    dist="--distance ${distance}"
+
+    # dist is set to 0 when histogram is enabled
+    histogram=""
+fi
+
 break=""
 if [ ${break_on} -gt 0 ]; then
     break="--breaktrace=${break_on}"
 fi
 
-cmd="taskset -c ${WORKLOAD_CPUS},${HK_CPUS} /usr/bin/cyclictest --policy $policy ${prio} --interval ${interval} --histofall 100 --histfile histogram.txt --duration ${duration} --quiet --affinity ${WORKLOAD_CPUS} --threads ${WORKLOAD_CPUS_COUNT} --mlockall --json cyclictest.json --mainaffinity ${HK_CPUS} --smi ${break}"
+cmd="taskset -c ${WORKLOAD_CPUS},${HK_CPUS} /usr/bin/cyclictest --policy $policy ${prio} --interval ${interval} ${dist} ${histogram} --duration ${duration} --quiet --affinity ${WORKLOAD_CPUS} --threads ${WORKLOAD_CPUS_COUNT} --mlockall --json cyclictest.json --mainaffinity ${HK_CPUS} --smi ${break}"
 echo "About to run: $cmd"
 date +%s.%N >begin.txt
 $cmd >cyclictest-bin-stderrout.txt 2>&1
@@ -118,4 +137,3 @@ date +%s.%N >end.txt
 if [ $rc -gt 0 ]; then
     exit_error "`cat cyclictest-bin-stderrout.txt`"
 fi
-    


### PR DESCRIPTION
-d, --distance=DIST
Set the distance of thread intervals in microseconds (default
is 500us).
When cyclictest is called with the -t option and more than one
thread is created, then this distance value is added to the
interval of the threads:

      Interval(thread N) = Interval(thread N-1) + DIST

distance=auto
	distance = interval / threads