### PR TITLE
Glibc headers fix for cyclictest on stream9

### DIFF
--- a/cyclictest-client
+++ b/cyclictest-client
@@ -128,7 +128,7 @@ case "${smi}" in
 	;;
 esac
 
-cmd="taskset -c ${WORKLOAD_CPUS},${HK_CPUS} /usr/bin/cyclictest --policy $policy ${prio} --interval ${interval} --histofall 100 --histfile histogram.txt --duration ${duration} --quiet --affinity ${WORKLOAD_CPUS} --threads ${WORKLOAD_CPUS_COUNT} --mlockall --json cyclictest.json --mainaffinity ${HK_CPUS} ${smi_arg} ${break}"
+cmd="taskset -c ${WORKLOAD_CPUS},${HK_CPUS} cyclictest --policy $policy ${prio} --interval ${interval} --histofall 100 --histfile histogram.txt --duration ${duration} --quiet --affinity ${WORKLOAD_CPUS} --threads ${WORKLOAD_CPUS_COUNT} --mlockall --json cyclictest.json --mainaffinity ${HK_CPUS} ${smi_arg} ${break}"
 echo "About to run: $cmd"
 date +%s.%N >begin.txt
 $cmd >cyclictest-bin-stderrout.txt 2>&1

--- a/rt-tests-glibc-headers.patch
+++ b/rt-tests-glibc-headers.patch
@@ -1,0 +1,36 @@
+diff --git a/src/include/rt-sched.h b/src/include/rt-sched.h
+index 80171c7..dafa7b3 100644
+--- a/src/include/rt-sched.h
++++ b/src/include/rt-sched.h
+@@ -42,6 +42,7 @@
+ #define __NR_sched_getattr		275
+ #endif
+ 
++#if ! __GLIBC_PREREQ(2, 34)
+ struct sched_attr {
+ 	uint32_t size;
+ 	uint32_t sched_policy;
+@@ -67,5 +68,6 @@ int sched_getattr(pid_t pid,
+ 		  struct sched_attr *attr,
+ 		  unsigned int size,
+ 		  unsigned int flags);
++#endif
+ 
+ #endif /* __RT_SCHED_H__ */
+diff --git a/src/lib/rt-sched.c b/src/lib/rt-sched.c
+index 8023bc7..59dea9b 100644
+--- a/src/lib/rt-sched.c
++++ b/src/lib/rt-sched.c
+@@ -14,6 +14,7 @@
+ 
+ #include "rt-sched.h"
+ 
++#if ! __GLIBC_PREREQ(2, 34)
+ int sched_setattr(pid_t pid,
+ 		  const struct sched_attr *attr,
+ 		  unsigned int flags)
+@@ -28,3 +29,4 @@ int sched_getattr(pid_t pid,
+ {
+ 	return syscall(__NR_sched_getattr, pid, attr, size, flags);
+ }
++#endif

--- a/workshop.json
+++ b/workshop.json
@@ -8,13 +8,34 @@
     {
       "name": "default",
       "requirements": [
+        "deps",
         "numactl_src",
         "rttests_src",
+        "stress-ng_src"
+      ]
+    },
+    {
+      "name": "stream9",
+      "requirements": [
+        "deps",
+        "numactl_src",
+        "rttests_patches",
+        "rttests_src_glibc",
         "stress-ng_src"
       ]
     }
   ],
   "requirements": [
+    {
+      "name": "deps",
+      "type": "distro",
+      "distro_info": {
+          "packages": [
+              "libtool",
+              "patch"
+          ]
+      }
+    },
     {
       "name": "numactl_src",
       "type": "source",
@@ -34,22 +55,43 @@
       }
     },
     {
-      "name": "rttests_src",
-      "type": "source",
-      "source_info": {
-        "url": "https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot/rt-tests-2.1.tar.gz",
-        "filename": "rt-tests-2.1.tar.gz",
-        "commands": {
-          "unpack": "tar -xzf rt-tests-2.1.tar.gz",
-          "get_dir": "tar -tzf rt-tests-2.1.tar.gz | head -n 1",
-          "commands": [
-            "make",
-            "make install",
-            "/bin/cp cyclictest /usr/bin",
-            "ldconfig"
-          ]
+        "name": "rttests_patches",
+        "type": "files",
+        "files_info": {
+            "files": [
+                {
+                    "src": "%bench-dir%/rt-tests-glibc-headers.patch",
+                    "dst": "/root"
+                }
+            ]
         }
-      }
+    },
+    {
+        "name": "rttests_src",
+        "type": "manual",
+        "manual_info": {
+            "commands": [
+                "git clone git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git /root/rt-tests",
+                "cd /root/rt-tests; git checkout v2.7",
+                "cd /root/rt-tests; make",
+                "cd /root/rt-tests; make install",
+                "ldconfig"
+            ]
+        }
+    },
+    {
+        "name": "rttests_src_glibc",
+        "type": "manual",
+        "manual_info": {
+            "commands": [
+                "git clone git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git /root/rt-tests",
+                "cd /root/rt-tests; git checkout v2.7",
+                "cd /root/rt-tests; patch -p1 < /root/rt-tests-glibc-headers.patch",
+                "cd /root/rt-tests; make",
+                "cd /root/rt-tests; make install",
+                "ldconfig"
+            ]
+        }
     },
     {
       "name": "stress-ng_src",


### PR DESCRIPTION
Get cyclictest from rt-tests upstream, pin to v2.7 tag, and patch glibc headers for stream9 userenv.