### PR TITLE
Fix sched_attr structure collision

### DIFF
--- a/rt-tests-sched-headers.patch
+++ b/rt-tests-sched-headers.patch
@@ -1,36 +1,44 @@
+commit 88acfb6feb289226aefffcad6b66a03ccd9507ab
+Author: Rafael Folco <rfolco@redhat.com>
+Date:   Thu Apr 10 12:39:29 2025 -0300
+
+    sched_h
+
 diff --git a/src/include/rt-sched.h b/src/include/rt-sched.h
-index 80171c7..dafa7b3 100644
+index 80171c7..e23d029 100644
 --- a/src/include/rt-sched.h
 +++ b/src/include/rt-sched.h
-@@ -42,6 +42,7 @@
+@@ -42,6 +42,8 @@
  #define __NR_sched_getattr		275
  #endif
  
-+#if ! __GLIBC_PREREQ(2, 34)
++#ifndef _LINUX_SCHED_TYPES_H
++
  struct sched_attr {
  	uint32_t size;
  	uint32_t sched_policy;
-@@ -67,5 +68,6 @@ int sched_getattr(pid_t pid,
- 		  struct sched_attr *attr,
+@@ -68,4 +70,5 @@ int sched_getattr(pid_t pid,
  		  unsigned int size,
  		  unsigned int flags);
-+#endif
  
++#endif /* _LINUX_SCHED_TYPES_H */
  #endif /* __RT_SCHED_H__ */
 diff --git a/src/lib/rt-sched.c b/src/lib/rt-sched.c
-index 8023bc7..59dea9b 100644
+index 8023bc7..9d4c5c8 100644
 --- a/src/lib/rt-sched.c
 +++ b/src/lib/rt-sched.c
-@@ -14,6 +14,7 @@
+@@ -14,6 +14,8 @@
  
  #include "rt-sched.h"
  
-+#if ! __GLIBC_PREREQ(2, 34)
++#ifndef _LINUX_SCHED_TYPES_H
++
  int sched_setattr(pid_t pid,
  		  const struct sched_attr *attr,
  		  unsigned int flags)
-@@ -28,3 +29,4 @@ int sched_getattr(pid_t pid,
+@@ -28,3 +30,5 @@ int sched_getattr(pid_t pid,
  {
  	return syscall(__NR_sched_getattr, pid, attr, size, flags);
  }
-+#endif
++
++#endif /* _LINUX_SCHED_TYPES_H */

--- a/workshop.json
+++ b/workshop.json
@@ -20,7 +20,7 @@
         "deps",
         "numactl_src",
         "rttests_patches",
-        "rttests_src_glibc",
+        "rttests_src_sched",
         "stress-ng_src"
       ]
     }
@@ -60,7 +60,7 @@
         "files_info": {
             "files": [
                 {
-                    "src": "%bench-dir%/rt-tests-glibc-headers.patch",
+                    "src": "%bench-dir%/rt-tests-sched-headers.patch",
                     "dst": "/root"
                 }
             ]
@@ -80,13 +80,13 @@
         }
     },
     {
-        "name": "rttests_src_glibc",
+        "name": "rttests_src_sched",
         "type": "manual",
         "manual_info": {
             "commands": [
                 "git clone git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git /root/rt-tests",
                 "cd /root/rt-tests; git checkout v2.7",
-                "cd /root/rt-tests; patch -p1 < /root/rt-tests-glibc-headers.patch",
+                "cd /root/rt-tests; patch -p1 < /root/rt-tests-sched-headers.patch",
                 "cd /root/rt-tests; make",
                 "cd /root/rt-tests; make install",
                 "ldconfig"


### PR DESCRIPTION
Changes copied from the following bench-oslat commit:

commit aa2198930096d524b98e9bdbed3827c67db020f7
Author: Rafael Folco <rfolco@redhat.com>
Date:   Thu Apr 10 12:44:19 2025 -0300

Fix sched_attr structure collision