### PR TITLE
fix: correct post-process and workshop.json filenames in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ Bash — all scripts
 | `cyclictest-client` | Client-side benchmark execution |
 | `cyclictest-server-start` / `cyclictest-server-stop` | Server lifecycle management |
 | `cyclictest-runtime` | Extracts runtime from command-line options |
-| `cyclictest-post-process` | Parses cyclictest output into crucible metrics |
-| `workshop.json` | Engine image build: compiles rt-tests from source |
+| `cyclictest-post-process.py` | Parses cyclictest output into crucible metrics |
+| `client-workshop.json` / `server-workshop.json` | Engine image build: compiles rt-tests from source |
 | `rt-tests-sched-headers.patch` | Patch applied to rt-tests source during build |
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Scripts and configuration to run the [cyclictest](https://wiki.linuxfoundation.o
 | `cyclictest-client` | Client execution script |
 | `cyclictest-server-start` / `cyclictest-server-stop` | Server lifecycle scripts |
 | `cyclictest-runtime` | Runtime extraction |
-| `cyclictest-post-process` | Post-processing: parses cyclictest output into crucible metrics |
-| `workshop.json` | Engine image build: compiles rt-tests from source |
+| `cyclictest-post-process.py` | Post-processing: parses cyclictest output into crucible metrics |
+| `client-workshop.json` / `server-workshop.json` | Engine image build: compiles rt-tests from source |


### PR DESCRIPTION
## Summary

- Fix `cyclictest-post-process` → `cyclictest-post-process.py` in README.md and CLAUDE.md
- Fix `workshop.json` → `client-workshop.json` / `server-workshop.json` in both files

Resolves #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)